### PR TITLE
Fix typo, tupels -> tuples

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -68,7 +68,7 @@ subsetByOverlaps(x, y, type = "equal", ignore.strand = TRUE)
 # Note that if were to mistakenly treat these as genomic ranges, then the set 
 # of 'equal' genomic tuples would be incorrect since treating these tuples as 
 # ranges ignores the "internal positions" (pos2).
-# The set of overlaps when correctly treated as genomic tupels:
+# The set of overlaps when correctly treated as genomic tuples:
 findOverlaps(x, y, type = "equal")
 # The set of overlaps when incorrected treated as genomic ranges:
 findOverlaps(as(x, "GRanges"), as(y, "GRanges"), type = 'equal')


### PR DESCRIPTION
Observed (and fixed) as part of my review for JOSS (https://github.com/openjournals/joss-reviews/issues/20) -- might be worth running some spell checkers :)